### PR TITLE
update the api for syncblock

### DIFF
--- a/bitherj/src/main/java/net/bither/bitherj/api/http/PrimerUrl.java
+++ b/bitherj/src/main/java/net/bither/bitherj/api/http/PrimerUrl.java
@@ -53,7 +53,7 @@ public class PrimerUrl {
     }
 
     public static final String GET_BY_ADDRESS = "https://explorer.primecoin.net/api/searchrawtransactions/%s";
-    public static final String GET_BY_SYNCBLOCK = "http://5ce2225be3ced20014d35603.mockapi.io/rest/pcoin/syncblock";
+    public static final String GET_BY_SYNCBLOCK = "https://explorer.primecoin.net/api/syncblock/";
 
 
     // bither blockChain


### PR DESCRIPTION
the new address "https://explorer.primecoin.net/api/syncblock/" is used for GET_BY_SYNCBLOCK.