### PR TITLE
Support addresses with unlimited transactions

### DIFF
--- a/bitherj/src/main/java/net/bither/bitherj/api/BlockChainMytransactionsApi.java
+++ b/bitherj/src/main/java/net/bither/bitherj/api/BlockChainMytransactionsApi.java
@@ -17,12 +17,12 @@ public class BlockChainMytransactionsApi extends HttpsGetResponse<String> {
         this.result = response;
     }
     public BlockChainMytransactionsApi(String address,int offset) {
-        String url = Utils.format(PrimerUrl.getByAddress(), address);
+        String url = Utils.format(PrimerUrl.getByAddress(), address, offset);
         setUrl(url);
     }
 
     public BlockChainMytransactionsApi(String address) {
-        String url = Utils.format(PrimerUrl.getByAddress(), address);
+        String url = Utils.format(PrimerUrl.getByAddress(), address, 0);
         setUrl(url);
     }
 

--- a/bitherj/src/main/java/net/bither/bitherj/api/http/PrimerUrl.java
+++ b/bitherj/src/main/java/net/bither/bitherj/api/http/PrimerUrl.java
@@ -52,9 +52,9 @@ public class PrimerUrl {
 
     }
 
-    public static final String GET_BY_ADDRESS = "https://explorer.primecoin.net/api/searchrawtransactions/%s";
+    public static final String GET_BY_ADDRESS = "https://explorer.primecoin.net/api/searchrawtransactions/%s/%d";
     public static final String GET_BY_SYNCBLOCK = "https://explorer.primecoin.net/api/syncblock/";
-    public static final String GET_BY_ADDRESS_TESTNET = "https://testexplorer.primecoin.net/api/searchrawtransactions/%s";
+    public static final String GET_BY_ADDRESS_TESTNET = "https://testexplorer.primecoin.net/api/searchrawtransactions/%s/%d";
     public static final String GET_BY_SYNCBLOCK_TESTNET = "https://testexplorer.primecoin.net/api/syncblock/";
     public static String getByAddress(){
         if(Utils.isTestNet()) return GET_BY_ADDRESS_TESTNET;

--- a/bitherj/src/main/java/net/bither/bitherj/utils/TransactionsUtil.java
+++ b/bitherj/src/main/java/net/bither/bitherj/utils/TransactionsUtil.java
@@ -795,8 +795,6 @@ public class TransactionsUtil {
                         transactions = TransactionsUtil.getTransactionsFromBither(jsonObject, storeBlockHeight);
                         transactions = AddressManager.getInstance().compressTxsForApi(transactions, address);
 
-                        Collections.sort(transactions, new ComparatorTx());
-                        address.initTxs(transactions);
                         txSum = txSum + transactions.size();
                         needGetTxs = transactions.size() > 0;
                         page++;
@@ -819,10 +817,10 @@ public class TransactionsUtil {
                         txSum = txSum + transactionCount;
                         if(0==transactionCount) needGetTxs = false;
                         transactions.addAll(compressTxList);
-                        Collections.sort(transactions, new ComparatorTx());
-                        address.initTxs(transactions);
                     }
                 }
+                Collections.sort(transactions, new ComparatorTx());
+                address.initTxs(transactions);
 
                 if (apiBlockCount < storeBlockHeight && storeBlockHeight - apiBlockCount < 100) {
                     BlockChain.getInstance().rollbackBlock(apiBlockCount);

--- a/bitherj/src/main/java/net/bither/bitherj/utils/TransactionsUtil.java
+++ b/bitherj/src/main/java/net/bither/bitherj/utils/TransactionsUtil.java
@@ -778,7 +778,6 @@ public class TransactionsUtil {
 
                 List<Tx> transactions = new ArrayList<Tx>();
 
-                int pageIndex = 0;
                 while (needGetTxs) {
 
                     // TODO: get data from bither.net else from blockchain.info
@@ -803,7 +802,7 @@ public class TransactionsUtil {
                         page++;
 
                     } else {
-                        BlockChainMytransactionsApi blockChainMytransactionsApi = new BlockChainMytransactionsApi(address.getAddress(),pageIndex);
+                        BlockChainMytransactionsApi blockChainMytransactionsApi = new BlockChainMytransactionsApi(address.getAddress(),txSum);
                         blockChainMytransactionsApi.handleHttpGet();
                         String txResult = blockChainMytransactionsApi.getResult();
                         JSONObject jsonObject = new JSONObject(txResult);
@@ -817,10 +816,9 @@ public class TransactionsUtil {
                         List<Tx> fromTxList  = TransactionsUtil.getTransactionsFromBlockChain(jsonObject, storeBlockHeight);
                         List<Tx> compressTxList = AddressManager.getInstance().compressTxsForApi(fromTxList, address);
                         int transactionCount = TransactionsUtil.getTransactionsCountFromBlockChain(jsonObject);
-                        pageIndex = pageIndex + transactionCount;
+                        txSum = txSum + transactionCount;
                         if(0==transactionCount) needGetTxs = false;
                         transactions.addAll(compressTxList);
-                        txSum = txSum + transactions.size();
                         Collections.sort(transactions, new ComparatorTx());
                         address.initTxs(transactions);
                     }


### PR DESCRIPTION
In the previous 0.1.0alpha version, the primer doesn't support addresses having transaction number larger than 1000. This limitation has been removed in this pull request by changing the format of searchrawtransactions. 