### PR TITLE
Update tx count when syncing an address

### DIFF
--- a/bitherj/src/main/java/net/bither/bitherj/core/Address.java
+++ b/bitherj/src/main/java/net/bither/bitherj/core/Address.java
@@ -58,6 +58,8 @@ public class Address implements Comparable<Address> {
     protected String address;
 
     protected boolean syncComplete = false;
+    protected boolean syncing = false;
+    protected int syncedTxsCount = 0;
     private long mSortTime;
     private long balance = 0;
     private boolean isFromXRandom;
@@ -73,11 +75,16 @@ public class Address implements Comparable<Address> {
     public Address(String address, byte[] pubKey, String encryptString, boolean isSyncComplete
             , boolean isFromXRandom) {
         this(address, pubKey, AddressManager.getInstance().getSortTime(!Utils.isEmpty
-                (encryptString)), isSyncComplete, isFromXRandom, false, encryptString);
+                (encryptString)), isSyncComplete, 0, isFromXRandom, false, encryptString);
 
     }
 
     public Address(String address, byte[] pubKey, long sortTime, boolean isSyncComplete,
+                   boolean isFromXRandom, boolean isTrashed, String encryptPrivKey) {
+        this(address, pubKey, sortTime, isSyncComplete, 0, isFromXRandom, isTrashed, encryptPrivKey);
+    }
+
+    public Address(String address, byte[] pubKey, long sortTime, boolean isSyncComplete, int syncedCount,
                    boolean isFromXRandom, boolean isTrashed, String encryptPrivKey) {
         this.encryptPrivKey = encryptPrivKey;
         this.address = address;
@@ -87,8 +94,9 @@ public class Address implements Comparable<Address> {
         this.isFromXRandom = isFromXRandom;
         this.isTrashed = isTrashed;
         this.updateBalance();
+        this.syncedTxsCount = syncedCount;
+        this.syncing = false;
     }
-
 
     public int txCount() {
         return AbstractDb.txProvider.txCount(this.address);
@@ -236,8 +244,24 @@ public class Address implements Comparable<Address> {
         return this.syncComplete;
     }
 
+    public boolean isSyncing() {
+        return this.syncing;
+    }
+
+    public int getSyncedTxsCount() {
+        return this.syncedTxsCount;
+    }
+
     public void setSyncComplete(boolean isSyncComplete) {
         this.syncComplete = isSyncComplete;
+    }
+
+    public void setSyncing(boolean isSyncing) {
+        this.syncing = isSyncing;
+    }
+
+    public void setSyncedTxsCount(int count) {
+        this.syncedTxsCount = count;
     }
 
     public boolean isFromXRandom() {
@@ -247,6 +271,10 @@ public class Address implements Comparable<Address> {
 
     public void updateSyncComplete() {
         AbstractDb.addressProvider.updateSyncComplete(Address.this);
+    }
+
+    public void updateSyncedTxsCount() {
+        AbstractDb.addressProvider.updateSyncedTxsCount(Address.this);
     }
 
     @Override

--- a/bitherj/src/main/java/net/bither/bitherj/db/AbstractDb.java
+++ b/bitherj/src/main/java/net/bither/bitherj/db/AbstractDb.java
@@ -74,6 +74,7 @@ public abstract class AbstractDb {
             ", is_xrandom integer not null" +
             ", is_trash integer not null" +
             ", is_synced integer not null" +
+            ", synced_count integer" +
             ", sort_time integer not null);";
     public static final String CREATE_HD_SEEDS_SQL = "create table if not exists hd_seeds " +
             "(hd_seed_id integer not null primary key autoincrement" +
@@ -319,6 +320,7 @@ public abstract class AbstractDb {
         public static final String IS_XRANDOM = "is_xrandom";
         public static final String IS_TRASH = "is_trash";
         public static final String IS_SYNCED = "is_synced";
+        public static final String SYNCED_COUNT = "synced_count";
         public static final String SORT_TIME = "sort_time";
     }
 

--- a/bitherj/src/main/java/net/bither/bitherj/db/IAddressProvider.java
+++ b/bitherj/src/main/java/net/bither/bitherj/db/IAddressProvider.java
@@ -83,6 +83,8 @@ public interface IAddressProvider {
 
     void updateSyncComplete(Address address);
 
+    void updateSyncedTxsCount(Address address);
+
     // alias
     Map<String, String> getAliases();
 

--- a/bitherj/src/main/java/net/bither/bitherj/db/imp/AbstractAddressProvider.java
+++ b/bitherj/src/main/java/net/bither/bitherj/db/imp/AbstractAddressProvider.java
@@ -700,7 +700,7 @@ public abstract class AbstractAddressProvider extends AbstractProvider implement
     //normal
     @Override
     public List<Address> getAddresses() {
-        String sql = "select address,encrypt_private_key,pub_key,is_xrandom,is_trash,is_synced,sort_time " +
+        String sql = "select address,encrypt_private_key,pub_key,is_xrandom,is_trash,is_synced,synced_count,sort_time " +
                 "from addresses  order by sort_time desc";
         final List<Address> addressList = new ArrayList<Address>();
         this.execQueryLoop(sql, null, new Function<ICursor, Void>() {
@@ -778,6 +778,12 @@ public abstract class AbstractAddressProvider extends AbstractProvider implement
     public void updateSyncComplete(Address address) {
         String sql = "update addresses set is_synced=? where address=?";
         this.execUpdate(sql, new String[]{address.isSyncComplete() ? "1" : "0", address.getAddress()});
+    }
+
+    @Override
+    public void updateSyncedTxsCount(Address address) {
+        String sql = "update addresses set synced_count=? where address=?";
+        this.execUpdate(sql, new String[]{address.getSyncedTxsCount() + "", address.getAddress()});
     }
 
     @Override
@@ -960,6 +966,11 @@ public abstract class AbstractAddressProvider extends AbstractProvider implement
         if (idColumn != -1) {
             isSynced = c.getInt(idColumn) == 1;
         }
+        int syncedCount = 0;
+        idColumn = c.getColumnIndex(AbstractDb.AddressesColumns.SYNCED_COUNT);
+        if (idColumn != -1) {
+            syncedCount = c.getInt(idColumn);
+        }
         idColumn = c.getColumnIndex(AbstractDb.AddressesColumns.IS_TRASH);
         if (idColumn != -1) {
             isTrash = c.getInt(idColumn) == 1;
@@ -968,7 +979,7 @@ public abstract class AbstractAddressProvider extends AbstractProvider implement
         if (idColumn != -1) {
             sortTime = c.getLong(idColumn);
         }
-        address = new Address(addressStr, pubKey, sortTime, isSynced, isXRandom, isTrash, encryptPrivateKey);
+        address = new Address(addressStr, pubKey, sortTime, isSynced, syncedCount, isXRandom, isTrash, encryptPrivateKey);
 
         return address;
     }

--- a/bitherj/src/main/java/net/bither/bitherj/utils/TransactionsUtil.java
+++ b/bitherj/src/main/java/net/bither/bitherj/utils/TransactionsUtil.java
@@ -770,9 +770,10 @@ public class TransactionsUtil {
                 storeBlockHeight = storedBlock.getBlockNo();
             }
 
-            if (!address.isSyncComplete()) {
+            if (!address.isSyncComplete() && !address.isSyncing()) {
+                address.setSyncing(true);
                 int apiBlockCount = 0;
-                int txSum = 0;
+                int txSum = address.getSyncedTxsCount();
                 boolean needGetTxs = true;
                 int page = 1;
 
@@ -817,6 +818,9 @@ public class TransactionsUtil {
                         txSum = txSum + transactionCount;
                         if(0==transactionCount) needGetTxs = false;
                         transactions.addAll(compressTxList);
+                        address.initTxs(compressTxList);
+                        address.setSyncedTxsCount(txSum);
+                        address.updateSyncedTxsCount();
                     }
                 }
                 Collections.sort(transactions, new ComparatorTx());
@@ -833,6 +837,7 @@ public class TransactionsUtil {
                 } else {
                     address.updateSyncComplete();
                 }
+                address.setSyncing(false);
             }
         }
 

--- a/bitherj/src/main/java/net/bither/bitherj/utils/TransactionsUtil.java
+++ b/bitherj/src/main/java/net/bither/bitherj/utils/TransactionsUtil.java
@@ -764,79 +764,84 @@ public class TransactionsUtil {
     //获取热钱包
     private  static void getTxForAddress(final int webType) throws Exception {
         for (Address address : AddressManager.getInstance().getAllAddresses()) {
-            Block storedBlock = BlockChain.getInstance().getLastBlock();
-            int storeBlockHeight = 0;
-            if (storedBlock != null) {
-                storeBlockHeight = storedBlock.getBlockNo();
-            }
+            try {
+                Block storedBlock = BlockChain.getInstance().getLastBlock();
+                int storeBlockHeight = 0;
+                if (storedBlock != null) {
+                    storeBlockHeight = storedBlock.getBlockNo();
+                }
 
-            if (!address.isSyncComplete() && !address.isSyncing()) {
-                address.setSyncing(true);
-                int apiBlockCount = 0;
-                int txSum = address.getSyncedTxsCount();
-                boolean needGetTxs = true;
-                int page = 1;
+                if (!address.isSyncComplete() && !address.isSyncing()) {
+                    address.setSyncing(true);
+                    int apiBlockCount = 0;
+                    int txSum = address.getSyncedTxsCount();
+                    boolean needGetTxs = true;
+                    int page = 1;
 
-                List<Tx> transactions = new ArrayList<Tx>();
+                    List<Tx> transactions = new ArrayList<Tx>();
 
-                while (needGetTxs) {
+                    while (needGetTxs) {
 
-                    // TODO: get data from bither.net else from blockchain.info
-                    if (webType == 0) {
-                        PrimerMytransactionsApi primerMytransactionsApi = new PrimerMytransactionsApi(
-                                address.getAddress(), page);
-                        primerMytransactionsApi.handleHttpGet();
-                        String txResult = primerMytransactionsApi.getResult();
-                        JSONObject jsonObject = new JSONObject(txResult);
+                        // TODO: get data from bither.net else from blockchain.info
+                        if (webType == 0) {
+                            PrimerMytransactionsApi primerMytransactionsApi = new PrimerMytransactionsApi(
+                                    address.getAddress(), page);
+                            primerMytransactionsApi.handleHttpGet();
+                            String txResult = primerMytransactionsApi.getResult();
+                            JSONObject jsonObject = new JSONObject(txResult);
 
-                        if (!jsonObject.isNull(BLOCK_COUNT)) {
-                            apiBlockCount = jsonObject.getInt(BLOCK_COUNT);
-                        }
-                        int txCnt = jsonObject.getInt(TX_CNT);
-                        transactions = TransactionsUtil.getTransactionsFromBither(jsonObject, storeBlockHeight);
-                        transactions = AddressManager.getInstance().compressTxsForApi(transactions, address);
+                            if (!jsonObject.isNull(BLOCK_COUNT)) {
+                                apiBlockCount = jsonObject.getInt(BLOCK_COUNT);
+                            }
+                            int txCnt = jsonObject.getInt(TX_CNT);
+                            transactions = TransactionsUtil.getTransactionsFromBither(jsonObject, storeBlockHeight);
+                            transactions = AddressManager.getInstance().compressTxsForApi(transactions, address);
 
-                        txSum = txSum + transactions.size();
-                        needGetTxs = transactions.size() > 0;
-                        page++;
+                            txSum = txSum + transactions.size();
+                            needGetTxs = transactions.size() > 0;
+                            page++;
 
-                    } else {
-                        BlockChainMytransactionsApi blockChainMytransactionsApi = new BlockChainMytransactionsApi(address.getAddress(),txSum);
-                        blockChainMytransactionsApi.handleHttpGet();
-                        String txResult = blockChainMytransactionsApi.getResult();
-                        JSONObject jsonObject = new JSONObject(txResult);
-                        // TODO: get the latest block number from blockChain.info
-                        JSONObject jsonObjectBlockChain = getLatestBlockNumberFromBlockchain();
-                        if (!jsonObjectBlockChain.isNull(BLOCK_CHAIN_HEIGHT)) {
-                            apiBlockCount = jsonObjectBlockChain.getInt(BLOCK_CHAIN_HEIGHT);
-                        }
+                        } else {
+                            BlockChainMytransactionsApi blockChainMytransactionsApi = new BlockChainMytransactionsApi(address.getAddress(), txSum);
+                            blockChainMytransactionsApi.handleHttpGet();
+                            String txResult = blockChainMytransactionsApi.getResult();
+                            JSONObject jsonObject = new JSONObject(txResult);
+                            // TODO: get the latest block number from blockChain.info
+                            JSONObject jsonObjectBlockChain = getLatestBlockNumberFromBlockchain();
+                            if (!jsonObjectBlockChain.isNull(BLOCK_CHAIN_HEIGHT)) {
+                                apiBlockCount = jsonObjectBlockChain.getInt(BLOCK_CHAIN_HEIGHT);
+                            }
 //                        int txCnt = jsonObject.getInt(BLOCK_CHAIN_CNT);
-                        // TODO: get transactions from blockChain.info
-                        List<Tx> fromTxList  = TransactionsUtil.getTransactionsFromBlockChain(jsonObject, storeBlockHeight);
-                        List<Tx> compressTxList = AddressManager.getInstance().compressTxsForApi(fromTxList, address);
-                        int transactionCount = TransactionsUtil.getTransactionsCountFromBlockChain(jsonObject);
-                        txSum = txSum + transactionCount;
-                        if(0==transactionCount) needGetTxs = false;
-                        transactions.addAll(compressTxList);
-                        address.initTxs(compressTxList);
-                        address.setSyncedTxsCount(txSum);
-                        address.updateSyncedTxsCount();
+                            // TODO: get transactions from blockChain.info
+                            List<Tx> fromTxList = TransactionsUtil.getTransactionsFromBlockChain(jsonObject, storeBlockHeight);
+                            List<Tx> compressTxList = AddressManager.getInstance().compressTxsForApi(fromTxList, address);
+                            int transactionCount = TransactionsUtil.getTransactionsCountFromBlockChain(jsonObject);
+                            txSum = txSum + transactionCount;
+                            if (0 == transactionCount) needGetTxs = false;
+                            transactions.addAll(compressTxList);
+                            address.initTxs(compressTxList);
+                            address.setSyncedTxsCount(txSum);
+                            address.updateSyncedTxsCount();
+                        }
+                    }
+                    Collections.sort(transactions, new ComparatorTx());
+                    address.initTxs(transactions);
+
+                    if (apiBlockCount < storeBlockHeight && storeBlockHeight - apiBlockCount < 100) {
+                        BlockChain.getInstance().rollbackBlock(apiBlockCount);
+                    }
+                    address.setSyncComplete(true);
+                    if (address instanceof HDMAddress) {
+                        HDMAddress hdmAddress = (HDMAddress) address;
+                        hdmAddress.
+                                updateSyncComplete();
+                    } else {
+                        address.updateSyncComplete();
                     }
                 }
-                Collections.sort(transactions, new ComparatorTx());
-                address.initTxs(transactions);
-
-                if (apiBlockCount < storeBlockHeight && storeBlockHeight - apiBlockCount < 100) {
-                    BlockChain.getInstance().rollbackBlock(apiBlockCount);
-                }
-                address.setSyncComplete(true);
-                if (address instanceof HDMAddress) {
-                    HDMAddress hdmAddress = (HDMAddress) address;
-                    hdmAddress.
-                            updateSyncComplete();
-                } else {
-                    address.updateSyncComplete();
-                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            } finally {
                 address.setSyncing(false);
             }
         }


### PR DESCRIPTION
A variable "syncedTxsCount" is added in the database to remember how many transactions have been loaded, so an interrupted loading process can be resumed. This is useful when the primer is cleaned by the android system.
A variable "syncing" is added to mark if a loading process is running, to avoid double loading to the same address.