### PR TITLE
modify compare tx to avoid violation of general contract

### DIFF
--- a/bitherj/src/main/java/net/bither/bitherj/core/Tx.java
+++ b/bitherj/src/main/java/net/bither/bitherj/core/Tx.java
@@ -355,25 +355,6 @@ public class Tx extends Message implements Comparable<Tx> {
         if (this.getBlockNo() != tx.getBlockNo()) {
             return tx.getBlockNo() - this.getBlockNo();
         } else {
-            boolean isTx2AfterTx1 = false;
-            for (In in : tx.getIns()) {
-                if (Arrays.equals(in.getPrevTxHash(), this.getTxHash())) {
-                    isTx2AfterTx1 = true;
-                    break;
-                }
-            }
-            if (isTx2AfterTx1) {
-                return 1;
-            }
-            boolean isTx1AfterTx2 = false;
-            for (In in : this.getIns()) {
-                if (Arrays.equals(in.getPrevTxHash(), tx.getTxHash())) {
-                    isTx1AfterTx2 = true;
-                }
-            }
-            if (isTx1AfterTx2) {
-                return -1;
-            }
             return tx.getTxTime() - this.getTxTime();
         }
     }


### PR DESCRIPTION
The comparison method for tx violates the general contract for partial order, which may make the primer crash at a few situations. I modified this comparison method by referring to  the one redefined in TransactionsUtil.java:
public static class ComparatorTx implements Comparator<Tx> {

        @Override
        public int compare(Tx lhs, Tx rhs) {
            if (lhs.getBlockNo() != rhs.getBlockNo()) {
                return Integer.valueOf(lhs.getBlockNo()).compareTo(Integer.valueOf(rhs.getBlockNo()));
            } else {
                return Integer.valueOf(lhs.getTxTime()).compareTo(Integer.valueOf(rhs.getTxTime()));
            }

        }

    }