### PR TITLE
abandon bad peer

### DIFF
--- a/bitherj/src/main/java/net/bither/bitherj/core/Peer.java
+++ b/bitherj/src/main/java/net/bither/bitherj/core/Peer.java
@@ -996,7 +996,7 @@ public class Peer extends PeerSocketHandler {
 
 
     public void connectFail() {
-        AbstractDb.peerProvider.conncetFail(getPeerAddress());
+        AbstractDb.peerProvider.connectFail(getPeerAddress());
     }
 
     public void connectError() {

--- a/bitherj/src/main/java/net/bither/bitherj/core/Peer.java
+++ b/bitherj/src/main/java/net/bither/bitherj/core/Peer.java
@@ -996,7 +996,7 @@ public class Peer extends PeerSocketHandler {
 
 
     public void connectFail() {
-        AbstractDb.peerProvider.removePeer(getPeerAddress());
+        AbstractDb.peerProvider.conncetFail(getPeerAddress());
     }
 
     public void connectError() {

--- a/bitherj/src/main/java/net/bither/bitherj/core/PeerManager.java
+++ b/bitherj/src/main/java/net/bither/bitherj/core/PeerManager.java
@@ -261,7 +261,7 @@ public class PeerManager {
         HashSet<Peer> peers = new HashSet<Peer>();
         Peer[] ps = DnsDiscovery.instance().getPeers(5, TimeUnit.SECONDS);
         Collections.addAll(peers, ps);
-        AbstractDb.peerProvider.addPeers(new ArrayList<Peer>(peers));
+        addRelayedPeers(new ArrayList<Peer>(peers));
         return peers;
     }
 

--- a/bitherj/src/main/java/net/bither/bitherj/db/IPeerProvider.java
+++ b/bitherj/src/main/java/net/bither/bitherj/db/IPeerProvider.java
@@ -31,6 +31,8 @@ public interface IPeerProvider {
 
     void connectSucceed(InetAddress address);
 
+    void conncetFail(InetAddress address);
+
     List<Peer> getPeersWithLimit(int limit);
 
     void cleanPeers();

--- a/bitherj/src/main/java/net/bither/bitherj/db/IPeerProvider.java
+++ b/bitherj/src/main/java/net/bither/bitherj/db/IPeerProvider.java
@@ -31,7 +31,7 @@ public interface IPeerProvider {
 
     void connectSucceed(InetAddress address);
 
-    void conncetFail(InetAddress address);
+    void connectFail(InetAddress address);
 
     List<Peer> getPeersWithLimit(int limit);
 

--- a/bitherj/src/main/java/net/bither/bitherj/db/imp/AbstractPeerProvider.java
+++ b/bitherj/src/main/java/net/bither/bitherj/db/imp/AbstractPeerProvider.java
@@ -102,26 +102,8 @@ public abstract class AbstractPeerProvider extends AbstractProvider implements I
 
     public void conncetFail(InetAddress address) {
         long addressLong = Utils.parseLongFromAddress(address);
-        String sql = "select count(0) cnt from peers where peer_address=? and peer_connected_cnt=0";
-        final int[] cnt = {0};
-        this.execQueryOneRecord(sql, new String[]{Long.toString(addressLong)}, new Function<ICursor, Void>() {
-            @Nullable
-            @Override
-            public Void apply(@Nullable ICursor c) {
-                int idColumn = c.getColumnIndex("cnt");
-                if (idColumn != -1) {
-                    cnt[0] = c.getInt(idColumn);
-                }
-                return null;
-            }
-        });
-        if (cnt[0] == 0) {
-            sql = "update peers set peer_connected_cnt=peer_connected_cnt+1 where peer_address=?";
-            this.execUpdate(sql, new String[] {Long.toString(addressLong)});
-        } else {
-            sql = "update peers set peer_connected_cnt=2 where peer_address=?";
-            this.execUpdate(sql, new String[]{Long.toString(addressLong)});
-        }
+        String sql = "update peers set peer_connected_cnt=peer_connected_cnt+1 where peer_address=?";
+        this.execUpdate(sql, new String[] {Long.toString(addressLong)});
     }
 
     public void connectSucceed(InetAddress address) {

--- a/bitherj/src/main/java/net/bither/bitherj/db/imp/AbstractPeerProvider.java
+++ b/bitherj/src/main/java/net/bither/bitherj/db/imp/AbstractPeerProvider.java
@@ -100,7 +100,7 @@ public abstract class AbstractPeerProvider extends AbstractProvider implements I
         this.execUpdate(sql, new String[] {Long.toString(Utils.parseLongFromAddress(address))});
     }
 
-    public void conncetFail(InetAddress address) {
+    public void connectFail(InetAddress address) {
         long addressLong = Utils.parseLongFromAddress(address);
         String sql = "update peers set peer_connected_cnt=peer_connected_cnt+1 where peer_address=?";
         this.execUpdate(sql, new String[] {Long.toString(addressLong)});


### PR DESCRIPTION
If a peer has timeout error for over 6 times, it will be abandoned. The abandoned peer may be recovered after restarting the primer.