### PR TITLE
Transaction syncing issue on one account address may lead to infinite loop retry

### DIFF
--- a/bitherj/src/main/java/net/bither/bitherj/core/Address.java
+++ b/bitherj/src/main/java/net/bither/bitherj/core/Address.java
@@ -58,6 +58,8 @@ public class Address implements Comparable<Address> {
     protected String address;
 
     protected boolean syncComplete = false;
+    private static final int MAX_SYNC_FAILURE_COUNT = 6;
+    protected int syncCount = 0;
     protected boolean syncing = false;
     protected int syncedTxsCount = 0;
     private long mSortTime;
@@ -532,5 +534,12 @@ public class Address implements Comparable<Address> {
         return vanityLen != VANITY_LEN_NO_EXSITS;
     }
 
+    public void syncFail() {
+        syncCount = syncCount + 1;
+    }
+
+    public boolean isSyncFailed() {
+        return (syncCount > MAX_SYNC_FAILURE_COUNT);
+    }
 
 }

--- a/bitherj/src/main/java/net/bither/bitherj/core/Address.java
+++ b/bitherj/src/main/java/net/bither/bitherj/core/Address.java
@@ -58,7 +58,7 @@ public class Address implements Comparable<Address> {
     protected String address;
 
     protected boolean syncComplete = false;
-    private static final int MAX_SYNC_FAILURE_COUNT = 6;
+    private static final int MAX_SYNC_FAILURE_COUNT = 3;
     protected int syncCount = 0;
     protected boolean syncing = false;
     protected int syncedTxsCount = 0;
@@ -538,7 +538,7 @@ public class Address implements Comparable<Address> {
         syncCount = syncCount + 1;
     }
 
-    public boolean isSyncFailed() {
+    public boolean isSyncRetryExceeded() {
         return (syncCount > MAX_SYNC_FAILURE_COUNT);
     }
 

--- a/bitherj/src/main/java/net/bither/bitherj/core/AddressManager.java
+++ b/bitherj/src/main/java/net/bither/bitherj/core/AddressManager.java
@@ -575,7 +575,7 @@ public class AddressManager implements HDMKeychain.HDMAddressChangeDelegate,
 
     public boolean addressIsSyncComplete() {
         for (Address address : AddressManager.getInstance().getAllAddresses()) {
-            if (!address.isSyncComplete()) {
+            if (!address.isSyncComplete() && !address.isSyncFailed()) {
                 return false;
             }
         }

--- a/bitherj/src/main/java/net/bither/bitherj/core/AddressManager.java
+++ b/bitherj/src/main/java/net/bither/bitherj/core/AddressManager.java
@@ -575,7 +575,7 @@ public class AddressManager implements HDMKeychain.HDMAddressChangeDelegate,
 
     public boolean addressIsSyncComplete() {
         for (Address address : AddressManager.getInstance().getAllAddresses()) {
-            if (!address.isSyncComplete() && !address.isSyncFailed()) {
+            if (!address.isSyncComplete() && !address.isSyncRetryExceeded()) {
                 return false;
             }
         }

--- a/bitherj/src/main/java/net/bither/bitherj/utils/TransactionsUtil.java
+++ b/bitherj/src/main/java/net/bither/bitherj/utils/TransactionsUtil.java
@@ -840,9 +840,9 @@ public class TransactionsUtil {
                     }
                 }
             } catch (Exception e) {
+                address.syncFail();
                 e.printStackTrace();
             } finally {
-                address.syncFail();
                 address.setSyncing(false);
             }
         }

--- a/bitherj/src/main/java/net/bither/bitherj/utils/TransactionsUtil.java
+++ b/bitherj/src/main/java/net/bither/bitherj/utils/TransactionsUtil.java
@@ -842,6 +842,7 @@ public class TransactionsUtil {
             } catch (Exception e) {
                 e.printStackTrace();
             } finally {
+                address.syncFail();
                 address.setSyncing(false);
             }
         }


### PR DESCRIPTION
The process of loading transactions for address can not coincide with syncing block. So, if an address fails in loading its transactions, it will repeat leading its tx endlessly, which results in the primer stop working. 
In this pr, the max times that an address can load its tx is limited to 6, and a syncCount is used to count failure times. If the primer is restarted, syncCount will be reset to zero automatically. 