### PR TITLE
Fix no peer case, retry all peers

### DIFF
--- a/bitherj/src/main/java/net/bither/bitherj/core/Peer.java
+++ b/bitherj/src/main/java/net/bither/bitherj/core/Peer.java
@@ -996,7 +996,7 @@ public class Peer extends PeerSocketHandler {
 
 
     public void connectFail() {
-        peerConnectedCnt = peerConnectedCnt + 1; // may be smaller than cnt in table peers
+        peerConnectedCnt = peerConnectedCnt + 1;
         AbstractDb.peerProvider.connectFail(getPeerAddress());
     }
 

--- a/bitherj/src/main/java/net/bither/bitherj/core/Peer.java
+++ b/bitherj/src/main/java/net/bither/bitherj/core/Peer.java
@@ -996,6 +996,7 @@ public class Peer extends PeerSocketHandler {
 
 
     public void connectFail() {
+        peerConnectedCnt = peerConnectedCnt + 1; // may be smaller than cnt in table peers
         AbstractDb.peerProvider.connectFail(getPeerAddress());
     }
 

--- a/bitherj/src/main/java/net/bither/bitherj/core/PeerManager.java
+++ b/bitherj/src/main/java/net/bither/bitherj/core/PeerManager.java
@@ -454,7 +454,7 @@ public class PeerManager {
             @Override
             public void run() {
                 if (reason == null || reason == Peer.DisconnectReason.Normal) {
-                    // peer.connectFail();
+                    peer.connectFail();
                 } else if (reason == Peer.DisconnectReason.Timeout) {
                     if (peer.getPeerConnectedCnt() > MAX_CONNECT_FAILURE_COUNT) {
                         // Failed too many times, we don't want to play with it any more.

--- a/bitherj/src/main/java/net/bither/bitherj/core/PeerManager.java
+++ b/bitherj/src/main/java/net/bither/bitherj/core/PeerManager.java
@@ -289,6 +289,10 @@ public class PeerManager {
                         result.add(peer);
                     }
                 }
+                if(result.isEmpty()){
+                    abandonPeers.clear();
+                    result.addAll(peers);
+                }
                 AbstractDb.peerProvider.addPeers(result);
                 AbstractDb.peerProvider.cleanPeers();
             }
@@ -450,7 +454,7 @@ public class PeerManager {
             @Override
             public void run() {
                 if (reason == null || reason == Peer.DisconnectReason.Normal) {
-                    peer.connectFail();
+                    // peer.connectFail();
                 } else if (reason == Peer.DisconnectReason.Timeout) {
                     if (peer.getPeerConnectedCnt() > MAX_CONNECT_FAILURE_COUNT) {
                         // Failed too many times, we don't want to play with it any more.
@@ -464,8 +468,6 @@ public class PeerManager {
                 }
                 int previousConnectedCount = connectedPeers.size();
                 connectedPeers.remove(peer);
-                log.info("Peer disconnected {} , remaining {} peers , reason: " + reason, peer
-                        .getPeerAddress().getHostAddress(), connectedPeers.size());
                 if (previousConnectedCount > 0 && connectedPeers.size() == 0) {
                     connected.set(false);
                     sendConnectedChangeBroadcast();


### PR DESCRIPTION
The abandoned peers cannot be retrieved. This may result in no peers finally, which should be avoided and has been fixed in this pr. 