### PR TITLE
Fix issue of not reconnecting to any peer

### DIFF
--- a/bitherj/src/main/java/net/bither/bitherj/core/PeerManager.java
+++ b/bitherj/src/main/java/net/bither/bitherj/core/PeerManager.java
@@ -259,7 +259,7 @@ public class PeerManager {
         if(peers.size() == 0) {
             sendConnectedChangeBroadcast();
         }
-        HashSet<Peer> result = deleteAbandonedPeers(peers);
+        HashSet<Peer> result = filterOutAbandonedPeers(peers);
         addRelayedPeers(new ArrayList<Peer>(result));
         return result;
     }
@@ -288,7 +288,7 @@ public class PeerManager {
         });
     }
 
-    private HashSet<Peer> deleteAbandonedPeers(HashSet<Peer> peers) {
+    private HashSet<Peer> filterOutAbandonedPeers(HashSet<Peer> peers) {
         HashSet<Peer> result = new HashSet<Peer>();
         for (Peer peer : peers) {
             if (!abandonPeers.contains(peer)) {
@@ -514,7 +514,7 @@ public class PeerManager {
         if (peers.size() > MaxPeerCount) {
             peers = peers.subList(0, MaxPeerCount);
         }
-        HashSet<Peer> result = deleteAbandonedPeers(new HashSet<Peer>(peers));
+        HashSet<Peer> result = filterOutAbandonedPeers(new HashSet<Peer>(peers));
         addRelayedPeers(new ArrayList<Peer>(result));
     }
 

--- a/bitherj/src/main/java/net/bither/bitherj/core/PeerManager.java
+++ b/bitherj/src/main/java/net/bither/bitherj/core/PeerManager.java
@@ -296,7 +296,7 @@ public class PeerManager {
                 result.add(peer);
             }
         }
-        if(result.isEmpty()){
+        if(peers.size()>0 && result.isEmpty()){
             abandonPeers.clear();
             result.addAll(peers);
             sendPeerCountChangeNotification();

--- a/bitherj/src/main/java/net/bither/bitherj/core/PeerManager.java
+++ b/bitherj/src/main/java/net/bither/bitherj/core/PeerManager.java
@@ -145,7 +145,6 @@ public class PeerManager {
                 for (Peer peer : connectedPeers) {
                     peer.connectError();
                     peer.disconnect();
-                    abandonPeers.add(peer);
                 }
                 connectedPeers.clear();
             }


### PR DESCRIPTION
Adding new peers to AbstractDb.peerProvider runs in a thread pool. The execution of this process may be delayed sometimes, which results in the failure of PeerManager restart due to network interrupt. 
This problem is fixed in this pr by ensuring that the bestPeers function returns something if no peer exits in the database. 