### PR TITLE
Fix NullPointerException in unit tests related to address

### DIFF
--- a/bitherj/src/main/java/net/bither/bitherj/ISetting.java
+++ b/bitherj/src/main/java/net/bither/bitherj/ISetting.java
@@ -45,7 +45,7 @@ public abstract class ISetting {
 
     public abstract PrimerjSettings.TransactionFeePrecision getTransactionFeePrecision();
 
-    public abstract boolean isTestNet();
+    public abstract PrimerjSettings.NetType getNetType();
 
     public abstract PrimerjSettings.ApiConfig getApiConfig();
 

--- a/bitherj/src/main/java/net/bither/bitherj/PrimerjSettings.java
+++ b/bitherj/src/main/java/net/bither/bitherj/PrimerjSettings.java
@@ -69,6 +69,7 @@ public class PrimerjSettings {
     public static final int addressHeader = 23;
     public static final int testNetAddressHeader = 111;
 
+    public static final int btcAddressHeader = 0;
     public static final int btgAddressHeader = 38;
     public static final int btwAddressHeader = 73;
     public static final int btfAddressHeader = 36;
@@ -76,20 +77,29 @@ public class PrimerjSettings {
 
     public static final int p2shHeader = 83;
     public static final int testNetP2shHeader = 196;
+    public static final int btcP2shHeader = 5;
     //    public static final int btgP2shHeader = 23;
     public static final int btgP2shHeader = 233;
     public static final int btwP2shHeader = 31;
     public static final int btfP2shHeader = 40;
     public static final int btpP2shHeader = 58;
 
-    public static int getAddressHeader() {
-        if(Utils.isTestNet()) return testNetAddressHeader;
-        else return addressHeader;
+    public static int getAddressHeader(NetType coinType) {
+        switch (coinType) {
+            case MAINNET: return addressHeader;
+            case TESTNET: return testNetAddressHeader;
+            case BITCOIN: return btcAddressHeader;
+            default: return addressHeader;
+        }
     }
 
-    public static int getP2shHeader() {
-        if(Utils.isTestNet()) return testNetP2shHeader;
-        else return p2shHeader;
+    public static int getP2shHeader(NetType coinType) {
+        switch (coinType) {
+            case MAINNET: return p2shHeader;
+            case TESTNET: return testNetP2shHeader;
+            case BITCOIN: return btcP2shHeader;
+            default: return p2shHeader;
+        }
     }
 
     public static long getPacketMagic() {
@@ -162,7 +172,17 @@ public class PrimerjSettings {
     public static final boolean ensureMinRequiredFee = true;
 
     public enum NetType {
-        MAINNET, TESTNET
+        MAINNET(24), TESTNET(1), BITCOIN(0); // BIP44 coin type
+
+        private int coinType;
+
+        NetType(int coinType) {
+            this.coinType = coinType;
+        }
+
+        public int getNetType() {
+            return coinType;
+        }
     }
 
     public enum TransactionFeeMode {
@@ -208,16 +228,14 @@ public class PrimerjSettings {
     }
 
     public static boolean validAddressPrefixPubkey(int pubkey) {
-        if (pubkey == getAddressHeader() || pubkey == btgAddressHeader || pubkey == btwAddressHeader ||
-                pubkey == btfAddressHeader || pubkey == btpAddressHeader) {
+        if (pubkey == addressHeader || pubkey == testNetAddressHeader || pubkey == btcAddressHeader) {
             return true;
         }
         return false;
     }
 
     public static boolean validAddressPrefixScript(int script) {
-        if (script == getP2shHeader() || script == btgP2shHeader || script == btwP2shHeader ||
-                script == btfP2shHeader || script == btpP2shHeader) {
+        if (script == p2shHeader || script == testNetP2shHeader || script == btcP2shHeader) {
             return true;
         }
         return false;

--- a/bitherj/src/main/java/net/bither/bitherj/core/Coin.java
+++ b/bitherj/src/main/java/net/bither/bitherj/core/Coin.java
@@ -82,7 +82,7 @@ public enum Coin {
             case BTW:
                 return PrimerjSettings.btwP2shHeader;
             default:
-                return PrimerjSettings.getP2shHeader();
+                return PrimerjSettings.btcP2shHeader;
         }
     }
 
@@ -97,7 +97,7 @@ public enum Coin {
             case BTW:
                 return PrimerjSettings.btwAddressHeader;
             default:
-                return PrimerjSettings.getAddressHeader();
+                return PrimerjSettings.btcAddressHeader;
         }
     }
 

--- a/bitherj/src/main/java/net/bither/bitherj/core/HDMAddress.java
+++ b/bitherj/src/main/java/net/bither/bitherj/core/HDMAddress.java
@@ -1,11 +1,10 @@
 package net.bither.bitherj.core;
 
-import net.bither.bitherj.db.AbstractDb;
-
 import net.bither.bitherj.crypto.TransactionSignature;
 import net.bither.bitherj.crypto.hd.DeterministicKey;
 import net.bither.bitherj.db.AbstractDb;
 import net.bither.bitherj.exception.PasswordException;
+import net.bither.bitherj.PrimerjSettings;
 import net.bither.bitherj.script.Script;
 import net.bither.bitherj.script.ScriptBuilder;
 import net.bither.bitherj.utils.Utils;
@@ -203,7 +202,11 @@ public class HDMAddress extends Address {
         }
 
         public String getAddress() {
-            return Utils.toP2SHAddress(Utils.sha256hash160(getMultiSigScript().getProgram()));
+            return getAddress(Utils.getNetType());
+        }
+
+        public String getAddress(PrimerjSettings.NetType coinType) {
+            return Utils.toP2SHAddress(Utils.sha256hash160(getMultiSigScript().getProgram()), coinType);
         }
     }
 

--- a/bitherj/src/main/java/net/bither/bitherj/core/Out.java
+++ b/bitherj/src/main/java/net/bither/bitherj/core/Out.java
@@ -17,8 +17,6 @@
 package net.bither.bitherj.core;
 
 import net.bither.bitherj.PrimerjSettings;
-
-import net.bither.bitherj.PrimerjSettings;
 import net.bither.bitherj.crypto.ECKey;
 import net.bither.bitherj.exception.ProtocolException;
 import net.bither.bitherj.exception.ScriptException;
@@ -157,10 +155,14 @@ public class Out extends Message {
     }
 
     public String getOutAddress() {
+        return getOutAddress(Utils.getNetType());
+    }
+
+    public String getOutAddress(PrimerjSettings.NetType coinType) {
         if (outAddress == null) {
             try {
                 Script pubKeyScript = new Script(this.getOutScript());
-                outAddress = pubKeyScript.getToAddress();
+                outAddress = pubKeyScript.getToAddress(coinType);
             } catch (ScriptException e) {
 //                if (this.getOutScript() != null) {
 //                    log.warn("out script : " + Utils.bytesToHexString(this.getOutScript()));

--- a/bitherj/src/main/java/net/bither/bitherj/core/SplitCoin.java
+++ b/bitherj/src/main/java/net/bither/bitherj/core/SplitCoin.java
@@ -142,7 +142,7 @@ public enum SplitCoin {
     public int getP2shHeader() {
         switch (this) {
             case BCC:
-                return PrimerjSettings.getP2shHeader();
+                return PrimerjSettings.btcP2shHeader;
             case BTG:
                 return PrimerjSettings.btgP2shHeader;
             case BTW:
@@ -152,13 +152,13 @@ public enum SplitCoin {
             case BTP:
                 return PrimerjSettings.btpP2shHeader;
         }
-        return PrimerjSettings.getP2shHeader();
+        return PrimerjSettings.btcP2shHeader;
     }
 
     public int getAddressHeader() {
         switch (this) {
             case BCC:
-                return PrimerjSettings.getAddressHeader();
+                return PrimerjSettings.btcAddressHeader;
             case BTG:
                 return PrimerjSettings.btgAddressHeader;
             case BTW:
@@ -168,7 +168,7 @@ public enum SplitCoin {
             case BTP:
                 return PrimerjSettings.btpAddressHeader;
         }
-        return PrimerjSettings.getAddressHeader();
+        return PrimerjSettings.btcAddressHeader;
     }
 
     public String getIsGatKey() {

--- a/bitherj/src/main/java/net/bither/bitherj/crypto/ECKey.java
+++ b/bitherj/src/main/java/net/bither/bitherj/crypto/ECKey.java
@@ -19,9 +19,7 @@ package net.bither.bitherj.crypto;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
-import net.bither.bitherj.utils.Sha256Hash;
-import net.bither.bitherj.utils.Utils;
-
+import net.bither.bitherj.PrimerjSettings;
 import net.bither.bitherj.utils.Sha256Hash;
 import net.bither.bitherj.utils.Utils;
 
@@ -360,6 +358,10 @@ public class ECKey implements Serializable {
      */
     public String toAddress() {
         return Utils.toAddress(Utils.sha256hash160(pub));
+    }
+
+    public String toAddress(PrimerjSettings.NetType coinType) {
+        return Utils.toAddress(Utils.sha256hash160(pub), coinType);
     }
 
     /**

--- a/bitherj/src/main/java/net/bither/bitherj/crypto/PasswordSeed.java
+++ b/bitherj/src/main/java/net/bither/bitherj/crypto/PasswordSeed.java
@@ -18,12 +18,8 @@ package net.bither.bitherj.crypto;
 
 
 import net.bither.bitherj.db.AbstractDb;
-import net.bither.bitherj.utils.Base58;
-import net.bither.bitherj.utils.PrivateKeyUtil;
-import net.bither.bitherj.utils.Utils;
-
-import net.bither.bitherj.db.AbstractDb;
 import net.bither.bitherj.exception.AddressFormatException;
+import net.bither.bitherj.PrimerjSettings;
 import net.bither.bitherj.qrcode.QRCodeUtil;
 import net.bither.bitherj.utils.Base58;
 import net.bither.bitherj.utils.PrivateKeyUtil;
@@ -47,12 +43,16 @@ public class PasswordSeed {
     }
 
     public boolean checkPassword(CharSequence password) {
+        return checkPassword(password, Utils.getNetType());
+    }
+
+    public boolean checkPassword(CharSequence password, PrimerjSettings.NetType coinType) {
         ECKey ecKey = PrivateKeyUtil.getECKeyFromSingleString(keyStr, password);
         String ecKeyAddress;
         if (ecKey == null) {
             return false;
         } else {
-            ecKeyAddress = ecKey.toAddress();
+            ecKeyAddress = ecKey.toAddress(coinType);
             ecKey.clearPrivateKey();
         }
         return Utils.compareString(this.address,

--- a/bitherj/src/main/java/net/bither/bitherj/script/Script.java
+++ b/bitherj/src/main/java/net/bither/bitherj/script/Script.java
@@ -27,18 +27,8 @@ import net.bither.bitherj.core.Tx;
 import net.bither.bitherj.crypto.ECKey;
 import net.bither.bitherj.crypto.TransactionSignature;
 import net.bither.bitherj.db.AbstractDb;
-import net.bither.bitherj.utils.UnsafeByteArrayOutputStream;
-import net.bither.bitherj.utils.Utils;
-
-import net.bither.bitherj.core.Coin;
-import net.bither.bitherj.core.In;
-import net.bither.bitherj.core.Out;
-import net.bither.bitherj.core.SplitCoin;
-import net.bither.bitherj.core.Tx;
-import net.bither.bitherj.crypto.ECKey;
-import net.bither.bitherj.crypto.TransactionSignature;
-import net.bither.bitherj.db.AbstractDb;
 import net.bither.bitherj.exception.ScriptException;
+import net.bither.bitherj.PrimerjSettings;
 import net.bither.bitherj.utils.UnsafeByteArrayOutputStream;
 import net.bither.bitherj.utils.Utils;
 
@@ -384,17 +374,21 @@ public class Script {
     }
 
     public String getFromAddress() throws ScriptException {
+        return getFromAddress(Utils.getNetType());
+    }
+
+    public String getFromAddress(PrimerjSettings.NetType coinType) throws ScriptException {
         if (this.chunks.size() == 2
                 && this.chunks.get(0).data != null && this.chunks.get(0).data.length > 2
                 && this.chunks.get(1).data != null && this.chunks.get(1).data.length > 2) {
-            return Utils.toAddress(Utils.sha256hash160(this.chunks.get(1).data));
+            return Utils.toAddress(Utils.sha256hash160(this.chunks.get(1).data), coinType);
         } else if (this.chunks.size() >= 3 && this.chunks.get(0).opcode == OP_0) {
             boolean isPay2SHScript = true;
             for (int i = 1; i < this.chunks.size(); i++) {
                 isPay2SHScript &= (this.chunks.get(i).data != null && this.chunks.get(i).data.length > 2);
             }
             if (isPay2SHScript) {
-                return Utils.toP2SHAddress(Utils.sha256hash160(this.chunks.get(this.chunks.size() - 1).data));
+                return Utils.toP2SHAddress(Utils.sha256hash160(this.chunks.get(this.chunks.size() - 1).data), coinType);
             }
         }
         return null;
@@ -404,8 +398,12 @@ public class Script {
      * Gets the destination address from this script, if it's in the required form (see getPubKey).
      */
     public String getToAddress() throws ScriptException {
+        return getToAddress(Utils.getNetType());
+    }
+
+    public String getToAddress(PrimerjSettings.NetType coinType) throws ScriptException {
         if (isSentToAddress())
-            return Utils.toAddress(getPubKeyHash());
+            return Utils.toAddress(getPubKeyHash(), coinType);
         else if (isSentToP2SH())
             return Utils.toP2SHAddress(this.getPubKeyHash());
         else

--- a/bitherj/src/main/java/net/bither/bitherj/utils/PrivateKeyUtil.java
+++ b/bitherj/src/main/java/net/bither/bitherj/utils/PrivateKeyUtil.java
@@ -22,13 +22,6 @@ import net.bither.bitherj.core.AddressManager;
 import net.bither.bitherj.core.HDAccount;
 import net.bither.bitherj.core.HDAccountCold;
 import net.bither.bitherj.core.HDMKeychain;
-
-import net.bither.bitherj.PrimerjSettings;
-import net.bither.bitherj.core.Address;
-import net.bither.bitherj.core.AddressManager;
-import net.bither.bitherj.core.HDAccount;
-import net.bither.bitherj.core.HDAccountCold;
-import net.bither.bitherj.core.HDMKeychain;
 import net.bither.bitherj.crypto.DumpedPrivateKey;
 import net.bither.bitherj.crypto.ECKey;
 import net.bither.bitherj.crypto.EncryptedData;
@@ -131,9 +124,9 @@ public class PrivateKeyUtil {
             AddressFormatException, InterruptedException {
         SecureCharSequence decrypted = getDecryptPrivateKeyString(address.getFullEncryptPrivKey()
                 , password);
-        String bip38 = Bip38.encryptNoEcMultiply(password, decrypted.toString());
+        String bip38 = Bip38.encryptNoEcMultiply(password, decrypted.toString(), Utils.getNetType());
         if (PrimerjSettings.DEV_DEBUG) {
-            SecureCharSequence d = Bip38.decrypt(bip38, password);
+            SecureCharSequence d = Bip38.decrypt(bip38, password, Utils.getNetType());
             if (d.equals(decrypted)) {
                 log.info("BIP38 right");
             } else {

--- a/bitherj/src/main/java/net/bither/bitherj/utils/Utils.java
+++ b/bitherj/src/main/java/net/bither/bitherj/utils/Utils.java
@@ -25,11 +25,6 @@ import net.bither.bitherj.AbstractApp;
 import net.bither.bitherj.PrimerjSettings;
 import net.bither.bitherj.core.Coin;
 import net.bither.bitherj.core.SplitCoin;
-
-import net.bither.bitherj.AbstractApp;
-import net.bither.bitherj.PrimerjSettings;
-import net.bither.bitherj.core.Coin;
-import net.bither.bitherj.core.SplitCoin;
 import net.bither.bitherj.crypto.DumpedPrivateKey;
 import net.bither.bitherj.crypto.SecureCharSequence;
 import net.bither.bitherj.exception.AddressFormatException;
@@ -699,10 +694,14 @@ public class Utils {
     }
 
     public static String toAddress(byte[] pubKeyHash) {
+        return toAddress(pubKeyHash, getNetType());
+    }
+
+    public static String toAddress(byte[] pubKeyHash, PrimerjSettings.NetType coinType) {
         checkArgument(pubKeyHash.length == 20, "Addresses are 160-bit hashes, " +
                 "so you must provide 20 bytes");
 
-        int version = PrimerjSettings.getAddressHeader();
+        int version = PrimerjSettings.getAddressHeader(coinType);
         checkArgument(version < 256 && version >= 0);
 
         byte[] addressBytes = new byte[1 + pubKeyHash.length + 4];
@@ -714,10 +713,14 @@ public class Utils {
     }
 
     public static String toP2SHAddress(byte[] pubKeyHash) {
+        return toP2SHAddress(pubKeyHash, getNetType());
+    }
+
+    public static String toP2SHAddress(byte[] pubKeyHash, PrimerjSettings.NetType coinType) {
         checkArgument(pubKeyHash.length == 20, "Addresses are 160-bit hashes, " +
                 "so you must provide 20 bytes");
 
-        int version = PrimerjSettings.getP2shHeader();
+        int version = PrimerjSettings.getP2shHeader(coinType);
         checkArgument(version < 256 && version >= 0);
 
         byte[] addressBytes = new byte[1 + pubKeyHash.length + 4];
@@ -761,7 +764,7 @@ public class Utils {
     public static String toSegwitAddress(byte[] pubKeyHash) {
         assert (pubKeyHash.length == 20);
 
-        int version = PrimerjSettings.getP2shHeader();
+        int version = PrimerjSettings.getP2shHeader(getNetType());
         assert (version < 256 && version >= 0);
 
         byte[] scriptSig = new byte[pubKeyHash.length + 2];
@@ -952,8 +955,12 @@ public class Utils {
         return AbstractApp.bitherjSetting.getTransactionFeePrecision().getPrecision();
     }
 
+    public static PrimerjSettings.NetType getNetType() {
+        return AbstractApp.bitherjSetting.getNetType();
+    }
+
     public static boolean isTestNet() {
-        return AbstractApp.bitherjSetting.isTestNet();
+        return (AbstractApp.bitherjSetting.getNetType() == PrimerjSettings.NetType.TESTNET);
     }
 
     public static long ceilingFee(long fee) {

--- a/bitherj/src/test/java/net/bither/bitherj/core/MultisigAddressTest.java
+++ b/bitherj/src/test/java/net/bither/bitherj/core/MultisigAddressTest.java
@@ -1,7 +1,6 @@
 package net.bither.bitherj.core;
 
-import net.bither.bitherj.utils.Utils;
-
+import net.bither.bitherj.PrimerjSettings;
 import net.bither.bitherj.utils.Utils;
 
 import org.junit.Assert;
@@ -31,7 +30,7 @@ public class MultisigAddressTest {
             TestCase c = cases[i];
             Assert.assertArrayEquals("script program not match", c.script, c.pubs.getMultiSigScript().getProgram());
             System.out.println("\nscript program match: " + Utils.bytesToHexString(c.script));
-            String a = c.pubs.getAddress();
+            String a = c.pubs.getAddress(PrimerjSettings.NetType.BITCOIN);
             assertEquals("address not match", a, c.address);
             System.out.println("\naddress match: " + a);
         }

--- a/bitherj/src/test/java/net/bither/bitherj/core/TestImplAbstractApp.java
+++ b/bitherj/src/test/java/net/bither/bitherj/core/TestImplAbstractApp.java
@@ -72,8 +72,8 @@ public class TestImplAbstractApp extends AbstractApp {
             }
 
             @Override
-            public boolean isTestNet() {
-                return false;
+            public PrimerjSettings.NetType getNetType() {
+                return PrimerjSettings.NetType.MAINNET;
             }
 
             @Override

--- a/bitherj/src/test/java/net/bither/bitherj/core/TxTest.java
+++ b/bitherj/src/test/java/net/bither/bitherj/core/TxTest.java
@@ -17,9 +17,7 @@
 package net.bither.bitherj.core;
 
 import net.bither.bitherj.db.AbstractDb;
-import net.bither.bitherj.utils.Utils;
-
-import net.bither.bitherj.db.AbstractDb;
+import net.bither.bitherj.PrimerjSettings;
 import net.bither.bitherj.utils.Utils;
 
 import org.junit.Test;
@@ -71,7 +69,7 @@ public class TxTest {
         byte[] exceptTxHash = Utils.reverseBytes(Utils.hexStringToByteArray("584985ca8a9ed57987da36ea3d13fe05a7c498f2098ddeb6c8d0f3214067640c"));
         byte[] txHash = tx.getTxHash();
         for (Out out : tx.getOuts()) {
-            String outAddress = out.getOutAddress();
+            String outAddress = out.getOutAddress(PrimerjSettings.NetType.BITCOIN);
         }
         assertTrue(Arrays.equals(exceptTxHash, txHash));
     }

--- a/bitherj/src/test/java/net/bither/bitherj/crypto/Bip38Test.java
+++ b/bitherj/src/test/java/net/bither/bitherj/crypto/Bip38Test.java
@@ -22,6 +22,7 @@ import net.bither.bitherj.utils.Utils;
 
 import net.bither.bitherj.crypto.bip38.Bip38;
 import net.bither.bitherj.exception.AddressFormatException;
+import net.bither.bitherj.PrimerjSettings;
 import net.bither.bitherj.utils.Utils;
 
 import org.junit.Assert;
@@ -37,7 +38,8 @@ public class Bip38Test {
     @Test
     public void testEncryptNoCompression() throws InterruptedException, AddressFormatException {
         String encoded = Bip38.encryptNoEcMultiply("TestingOneTwoThree",
-                "5KN7MzqK5wt2TP1fQCYyHBtDrXdJuXbUzm4A9rKAteGu3Qi5CVR");
+                "5KN7MzqK5wt2TP1fQCYyHBtDrXdJuXbUzm4A9rKAteGu3Qi5CVR",
+                PrimerjSettings.NetType.BITCOIN);
         assertEquals(encoded, "6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEbn2Nh2ZoGg");
         assertTrue(Bip38.isBip38PrivateKey(encoded));
     }
@@ -46,21 +48,21 @@ public class Bip38Test {
     @Test
     public void testDecryptNoCompression() throws InterruptedException, AddressFormatException {
         SecureCharSequence decoded = Bip38.decrypt("6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEbn2Nh2ZoGg",
-                "TestingOneTwoThree");
+                "TestingOneTwoThree", PrimerjSettings.NetType.BITCOIN);
         assertEquals(decoded.toString(), "5KN7MzqK5wt2TP1fQCYyHBtDrXdJuXbUzm4A9rKAteGu3Qi5CVR");
     }
 
     @Test
     public void testDecryptNoCompressionWithBom() throws InterruptedException, AddressFormatException {
         SecureCharSequence decoded = Bip38.decrypt("\uFEFF6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEbn2Nh2ZoGg",
-                "TestingOneTwoThree");
+                "TestingOneTwoThree", PrimerjSettings.NetType.BITCOIN);
         assertEquals(decoded.toString(), "5KN7MzqK5wt2TP1fQCYyHBtDrXdJuXbUzm4A9rKAteGu3Qi5CVR");
     }
 
     @Test
     public void testEncryptCompression1() throws InterruptedException, AddressFormatException {
         String encoded = Bip38.encryptNoEcMultiply("TestingOneTwoThree",
-                "L44B5gGEpqEDRS9vVPz7QT35jcBG2r3CZwSwQ4fCewXAhAhqGVpP");
+                "L44B5gGEpqEDRS9vVPz7QT35jcBG2r3CZwSwQ4fCewXAhAhqGVpP", PrimerjSettings.NetType.BITCOIN);
         assertEquals(encoded, "6PYNKZ1EAgYgmQfmNVamxyXVWHzK5s6DGhwP4J5o44cvXdoY7sRzhtpUeo");
         assertTrue(Bip38.isBip38PrivateKey(encoded));
     }
@@ -68,20 +70,20 @@ public class Bip38Test {
     @Test
     public void testDecryptCompression1() throws InterruptedException, AddressFormatException {
         SecureCharSequence decoded = Bip38.decrypt("6PYNKZ1EAgYgmQfmNVamxyXVWHzK5s6DGhwP4J5o44cvXdoY7sRzhtpUeo",
-                "TestingOneTwoThree");
+                "TestingOneTwoThree", PrimerjSettings.NetType.BITCOIN);
         assertEquals(decoded.toString(), "L44B5gGEpqEDRS9vVPz7QT35jcBG2r3CZwSwQ4fCewXAhAhqGVpP");
     }
 
     @Test
     public void testDecryptCompression1WithBom() throws InterruptedException, AddressFormatException {
         SecureCharSequence decoded = Bip38.decrypt("\uFEFF6PYNKZ1EAgYgmQfmNVamxyXVWHzK5s6DGhwP4J5o44cvXdoY7sRzhtpUeo",
-                "TestingOneTwoThree");
+                "TestingOneTwoThree", PrimerjSettings.NetType.BITCOIN);
         assertEquals(decoded.toString(), "L44B5gGEpqEDRS9vVPz7QT35jcBG2r3CZwSwQ4fCewXAhAhqGVpP");
     }
 
     @Test
     public void testEncryptCompression2() throws InterruptedException, AddressFormatException {
-        String encoded = Bip38.encryptNoEcMultiply("Satoshi", "KwYgW8gcxj1JWJXhPSu4Fqwzfhp5Yfi42mdYmMa4XqK7NJxXUSK7"
+        String encoded = Bip38.encryptNoEcMultiply("Satoshi", "KwYgW8gcxj1JWJXhPSu4Fqwzfhp5Yfi42mdYmMa4XqK7NJxXUSK7", PrimerjSettings.NetType.BITCOIN
         );
         assertEquals(encoded, "6PYLtMnXvfG3oJde97zRyLYFZCYizPU5T3LwgdYJz1fRhh16bU7u6PPmY7");
         assertTrue(Bip38.isBip38PrivateKey(encoded));
@@ -89,51 +91,51 @@ public class Bip38Test {
 
     @Test
     public void testDecryptCompression2() throws InterruptedException, AddressFormatException {
-        SecureCharSequence decoded = Bip38.decrypt("6PYLtMnXvfG3oJde97zRyLYFZCYizPU5T3LwgdYJz1fRhh16bU7u6PPmY7", "Satoshi");
+        SecureCharSequence decoded = Bip38.decrypt("6PYLtMnXvfG3oJde97zRyLYFZCYizPU5T3LwgdYJz1fRhh16bU7u6PPmY7", "Satoshi", PrimerjSettings.NetType.BITCOIN);
         assertEquals(decoded.toString(), "KwYgW8gcxj1JWJXhPSu4Fqwzfhp5Yfi42mdYmMa4XqK7NJxXUSK7");
     }
 
     @Test
     public void testDecryptCompression2WithBom() throws InterruptedException, AddressFormatException {
-        SecureCharSequence decoded = Bip38.decrypt("\uFEFF6PYLtMnXvfG3oJde97zRyLYFZCYizPU5T3LwgdYJz1fRhh16bU7u6PPmY7", "Satoshi");
+        SecureCharSequence decoded = Bip38.decrypt("\uFEFF6PYLtMnXvfG3oJde97zRyLYFZCYizPU5T3LwgdYJz1fRhh16bU7u6PPmY7", "Satoshi", PrimerjSettings.NetType.BITCOIN);
         assertEquals(decoded.toString(), "KwYgW8gcxj1JWJXhPSu4Fqwzfhp5Yfi42mdYmMa4XqK7NJxXUSK7");
     }
 
     @Test
     public void testDecryptNoCompressionWithEcMultiplyNoLot1() throws InterruptedException, AddressFormatException {
         SecureCharSequence decoded = Bip38.decrypt("6PfQu77ygVyJLZjfvMLyhLMQbYnu5uguoJJ4kMCLqWwPEdfpwANVS76gTX",
-                "TestingOneTwoThree");
+                "TestingOneTwoThree", PrimerjSettings.NetType.BITCOIN);
         assertEquals(decoded.toString(), "5K4caxezwjGCGfnoPTZ8tMcJBLB7Jvyjv4xxeacadhq8nLisLR2");
     }
 
     @Test
     public void testDecryptNoCompressionWithEcMultiplyNoLot1WithBom() throws InterruptedException, AddressFormatException {
         SecureCharSequence decoded = Bip38.decrypt("\uFEFF6PfQu77ygVyJLZjfvMLyhLMQbYnu5uguoJJ4kMCLqWwPEdfpwANVS76gTX",
-                "TestingOneTwoThree");
+                "TestingOneTwoThree", PrimerjSettings.NetType.BITCOIN);
         assertEquals(decoded.toString(), "5K4caxezwjGCGfnoPTZ8tMcJBLB7Jvyjv4xxeacadhq8nLisLR2");
     }
 
     @Test
     public void testDecryptNoCompressionWithEcMultiplyNoLot2() throws InterruptedException, AddressFormatException {
-        SecureCharSequence decoded = Bip38.decrypt("6PfLGnQs6VZnrNpmVKfjotbnQuaJK4KZoPFrAjx1JMJUa1Ft8gnf5WxfKd", "Satoshi");
+        SecureCharSequence decoded = Bip38.decrypt("6PfLGnQs6VZnrNpmVKfjotbnQuaJK4KZoPFrAjx1JMJUa1Ft8gnf5WxfKd", "Satoshi", PrimerjSettings.NetType.BITCOIN);
         assertEquals(decoded.toString(), "5KJ51SgxWaAYR13zd9ReMhJpwrcX47xTJh2D3fGPG9CM8vkv5sH");
     }
 
     @Test
     public void testDecryptNoCompressionWithEcMultiplyNoLot2WithBom() throws InterruptedException, AddressFormatException {
-        SecureCharSequence decoded = Bip38.decrypt("\uFEFF6PfLGnQs6VZnrNpmVKfjotbnQuaJK4KZoPFrAjx1JMJUa1Ft8gnf5WxfKd", "Satoshi");
+        SecureCharSequence decoded = Bip38.decrypt("\uFEFF6PfLGnQs6VZnrNpmVKfjotbnQuaJK4KZoPFrAjx1JMJUa1Ft8gnf5WxfKd", "Satoshi", PrimerjSettings.NetType.BITCOIN);
         assertEquals(decoded.toString(), "5KJ51SgxWaAYR13zd9ReMhJpwrcX47xTJh2D3fGPG9CM8vkv5sH");
     }
 
     @Test
     public void testDecryptNoCompressionWithEcMultiplyWithLot1() throws InterruptedException, AddressFormatException {
-        SecureCharSequence decoded = Bip38.decrypt("6PgNBNNzDkKdhkT6uJntUXwwzQV8Rr2tZcbkDcuC9DZRsS6AtHts4Ypo1j", "MOLON LABE");
+        SecureCharSequence decoded = Bip38.decrypt("6PgNBNNzDkKdhkT6uJntUXwwzQV8Rr2tZcbkDcuC9DZRsS6AtHts4Ypo1j", "MOLON LABE", PrimerjSettings.NetType.BITCOIN);
         assertEquals(decoded.toString(), "5JLdxTtcTHcfYcmJsNVy1v2PMDx432JPoYcBTVVRHpPaxUrdtf8");
     }
 
     @Test
     public void testDecryptNoCompressionWithEcMultiplyWithLot1WithBom() throws InterruptedException, AddressFormatException {
-        SecureCharSequence decoded = Bip38.decrypt("\uFEFF6PgNBNNzDkKdhkT6uJntUXwwzQV8Rr2tZcbkDcuC9DZRsS6AtHts4Ypo1j", "MOLON LABE");
+        SecureCharSequence decoded = Bip38.decrypt("\uFEFF6PgNBNNzDkKdhkT6uJntUXwwzQV8Rr2tZcbkDcuC9DZRsS6AtHts4Ypo1j", "MOLON LABE", PrimerjSettings.NetType.BITCOIN);
         assertEquals(decoded.toString(), "5JLdxTtcTHcfYcmJsNVy1v2PMDx432JPoYcBTVVRHpPaxUrdtf8");
     }
 
@@ -142,7 +144,7 @@ public class Bip38Test {
         // "MOLON LABE" using greek characters  = "ΜΟΛΩΝ ΛΑΒΕ"
         String passphrase = "\u039C\u039F\u039B\u03A9\u039D \u039B\u0391\u0392\u0395";
         Assert.assertEquals("ce9cce9fce9bcea9ce9d20ce9bce91ce92ce95".toUpperCase(), Utils.bytesToHexString(passphrase.getBytes("UTF-8")));
-        SecureCharSequence decoded = Bip38.decrypt("6PgGWtx25kUg8QWvwuJAgorN6k9FbE25rv5dMRwu5SKMnfpfVe5mar2ngH", passphrase);
+        SecureCharSequence decoded = Bip38.decrypt("6PgGWtx25kUg8QWvwuJAgorN6k9FbE25rv5dMRwu5SKMnfpfVe5mar2ngH", passphrase, PrimerjSettings.NetType.BITCOIN);
         assertEquals(decoded.toString(), "5KMKKuUmAkiNbA3DazMQiLfDq47qs8MAEThm4yL8R2PhV1ov33D");
     }
 
@@ -151,7 +153,7 @@ public class Bip38Test {
         // "MOLON LABE" using greek characters  = "ΜΟΛΩΝ ΛΑΒΕ"
         String passphrase = "\u039C\u039F\u039B\u03A9\u039D \u039B\u0391\u0392\u0395";
         assertEquals("ce9cce9fce9bcea9ce9d20ce9bce91ce92ce95".toUpperCase(), Utils.bytesToHexString(passphrase.getBytes("UTF-8")));
-        SecureCharSequence decoded = Bip38.decrypt("\uFEFF6PgGWtx25kUg8QWvwuJAgorN6k9FbE25rv5dMRwu5SKMnfpfVe5mar2ngH", passphrase);
+        SecureCharSequence decoded = Bip38.decrypt("\uFEFF6PgGWtx25kUg8QWvwuJAgorN6k9FbE25rv5dMRwu5SKMnfpfVe5mar2ngH", passphrase, PrimerjSettings.NetType.BITCOIN);
         assertEquals(decoded.toString(), "5KMKKuUmAkiNbA3DazMQiLfDq47qs8MAEThm4yL8R2PhV1ov33D");
     }
 }

--- a/bitherj/src/test/java/net/bither/bitherj/crypto/MultisigTest.java
+++ b/bitherj/src/test/java/net/bither/bitherj/crypto/MultisigTest.java
@@ -1,9 +1,6 @@
 package net.bither.bitherj.crypto;
 
-import net.bither.bitherj.script.Script;
-import net.bither.bitherj.script.ScriptBuilder;
-import net.bither.bitherj.utils.Utils;
-
+import net.bither.bitherj.PrimerjSettings;
 import net.bither.bitherj.script.Script;
 import net.bither.bitherj.script.ScriptBuilder;
 import net.bither.bitherj.utils.Utils;
@@ -35,7 +32,7 @@ public class MultisigTest {
         pubKeyList.add(keyRemote.getPubKey());
 
         Script script = ScriptBuilder.createMultiSigOutputScript(2, pubKeyList);
-        String multisigAddress = Utils.toP2SHAddress(Utils.sha256hash160(script.getProgram()));
+        String multisigAddress = Utils.toP2SHAddress(Utils.sha256hash160(script.getProgram()), PrimerjSettings.NetType.BITCOIN);
 
         assertEquals(address, multisigAddress);
 
@@ -53,7 +50,7 @@ public class MultisigTest {
         pubKeyList.add(keyRemote.getPubKey());
 
         script = ScriptBuilder.createMultiSigOutputScript(2, pubKeyList);
-        multisigAddress = Utils.toP2SHAddress(Utils.sha256hash160(script.getProgram()));
+        multisigAddress = Utils.toP2SHAddress(Utils.sha256hash160(script.getProgram()), PrimerjSettings.NetType.BITCOIN);
 
         assertEquals(address, multisigAddress);
 
@@ -71,7 +68,7 @@ public class MultisigTest {
         pubKeyList.add(keyRemote.getPubKey());
 
         script = ScriptBuilder.createMultiSigOutputScript(2, pubKeyList);
-        multisigAddress = Utils.toP2SHAddress(Utils.sha256hash160(script.getProgram()));
+        multisigAddress = Utils.toP2SHAddress(Utils.sha256hash160(script.getProgram()), PrimerjSettings.NetType.BITCOIN);
 
         assertEquals(address, multisigAddress);
     }

--- a/bitherj/src/test/java/net/bither/bitherj/crypto/PasswordSeedTest.java
+++ b/bitherj/src/test/java/net/bither/bitherj/crypto/PasswordSeedTest.java
@@ -2,13 +2,15 @@ package net.bither.bitherj.crypto;
 
 import org.junit.Test;
 
+import net.bither.bitherj.PrimerjSettings;
+
 public class PasswordSeedTest {
 
     @Test
     public void testPasswordTest() {
         String keyString = "0077b3dad72529632b0728128cba3e70edea7b047b/548BA5896EBFF2DEB66E8D697987222E9B3C7AEE0C6B7580235FCEE1FD3D1119408EB3927DED776F56231AD0FE8AB912/DBE9FAE06805DB4E91C7448B1F7A26F1/014f626c0177990ca5";
         PasswordSeed passwordSeed = new PasswordSeed(keyString);
-        boolean reslut = passwordSeed.checkPassword("123456");
+        boolean reslut = passwordSeed.checkPassword("123456", PrimerjSettings.NetType.BITCOIN);
         if (reslut) {
             System.out.println("checkPassword pass");
         } else {

--- a/bitherj/src/test/java/net/bither/bitherj/crypto/hd/HDDerivationTest.java
+++ b/bitherj/src/test/java/net/bither/bitherj/crypto/hd/HDDerivationTest.java
@@ -1,7 +1,6 @@
 package net.bither.bitherj.crypto.hd;
 
-import net.bither.bitherj.utils.Utils;
-
+import net.bither.bitherj.PrimerjSettings;
 import net.bither.bitherj.utils.Utils;
 
 import org.junit.Test;
@@ -85,8 +84,8 @@ public class HDDerivationTest {
             for (int j = 0; j < tc.addresses.length; j++) {
                 DeterministicKey key = external.deriveSoftened(j);
                 DeterministicKey keyPub = externalPub.deriveSoftened(j);
-                assertEquals(tc.addresses[j], Utils.toAddress(key.getPubKeyHash()));
-                assertEquals(tc.addresses[j], Utils.toAddress(keyPub.getPubKeyHash()));
+                assertEquals(tc.addresses[j], Utils.toAddress(key.getPubKeyHash(), PrimerjSettings.NetType.BITCOIN));
+                assertEquals(tc.addresses[j], Utils.toAddress(keyPub.getPubKeyHash(), PrimerjSettings.NetType.BITCOIN));
             }
 
             System.out.println("time " + i + ", " + (System.currentTimeMillis() - begin));
@@ -162,7 +161,7 @@ public class HDDerivationTest {
 
             for (int j = 0; j < tc.addresses.length; j++) {
                 DeterministicKey key = external.deriveSoftened(j);
-                assertEquals(tc.addresses[j], Utils.toAddress(key.getPubKeyHash()));
+                assertEquals(tc.addresses[j], Utils.toAddress(key.getPubKeyHash(), PrimerjSettings.NetType.BITCOIN));
             }
 
             System.out.println("der pub time " + i + ", " + (System.currentTimeMillis() - begin));

--- a/bitherj/src/test/java/net/bither/bitherj/script/ScriptTest.java
+++ b/bitherj/src/test/java/net/bither/bitherj/script/ScriptTest.java
@@ -25,17 +25,7 @@ import net.bither.bitherj.core.Tx;
 import net.bither.bitherj.crypto.ECKey;
 import net.bither.bitherj.exception.ScriptException;
 import net.bither.bitherj.exception.VerificationException;
-import net.bither.bitherj.utils.Base58;
-import net.bither.bitherj.utils.Sha256Hash;
-import net.bither.bitherj.utils.UnsafeByteArrayOutputStream;
-import net.bither.bitherj.utils.Utils;
-
-import net.bither.bitherj.core.In;
-import net.bither.bitherj.core.OutPoint;
-import net.bither.bitherj.core.Tx;
-import net.bither.bitherj.crypto.ECKey;
-import net.bither.bitherj.exception.ScriptException;
-import net.bither.bitherj.exception.VerificationException;
+import net.bither.bitherj.PrimerjSettings;
 import net.bither.bitherj.utils.Base58;
 import net.bither.bitherj.utils.Sha256Hash;
 import net.bither.bitherj.utils.UnsafeByteArrayOutputStream;
@@ -561,7 +551,7 @@ public class ScriptTest {
     public void testFromAddress() {
         byte[] rawTx = Utils.hexStringToByteArray("0100000001f98a280010ea7397485a2cbde9e6355deeca50b9b73eba5011f2248da1c9d12c00000000fc00463043021f149e45355bbb45b9d70aa2a30a707da871a7e97bf6e5e82ee679ffe078794f02202e94a43d1df4a9659cf187026bea5581c0db7050b70ae4a8c2340dd7353577bf0148304502210087d0e3f03c68a8962dc203a5491ea31d39f78652f241b5aff2b04a2f77a113990220335e5191ab93b54e9fdee18c06c1713ed1da85e92fb2f96ecff3e7f82362c81c014c695221031b2e51069f115a662fafdbe92347ddcbca693df1cfb96a0c41ce46b57fd746e2210202d41f339f2ca186eacf1fe31f8ff5e8ddf376745a96642a7439c3be7bad70662102951d6cbde04a9fdcf036befb767c96f17a4a3d20ab1a01c147f38b6c035e652853aeffffffff02102700000000000017a9145b39adef84a2728e5b147c1d57c11a1660bb31c787a85b01000000000017a914bc6333c8a2fd1b9be0094bfe6d846ff0298636768700000000");
         Tx tx = new Tx(rawTx);
-        String fromAddress = new Script(tx.getIns().get(0).getInSignature()).getFromAddress();
+        String fromAddress = new Script(tx.getIns().get(0).getInSignature()).getFromAddress(PrimerjSettings.NetType.BITCOIN);
 
         String expected = "3Js7oJY1qc5VH1erNuLCkTm3cHMZvApn1X";
         assertEquals(expected, fromAddress);


### PR DESCRIPTION
Address was no longer done statically when testnet was supported. This patch allows some address related calculations be done statically again, via calling related methods specifying NetType (coinType).
Expand NetType to include Bitcoin for unit testing purposes.
Fix NullPointerException in unit tests related to this.
Broken unit tests down to 23 from 29.