### PR TITLE
Fix testnet private key wif

### DIFF
--- a/bitherj/src/main/java/net/bither/bitherj/PrimerjSettings.java
+++ b/bitherj/src/main/java/net/bither/bitherj/PrimerjSettings.java
@@ -102,13 +102,15 @@ public class PrimerjSettings {
         }
     }
 
+    public static int getDumpedPrivateKeyHeader(NetType coinType) {
+        return (128 + getAddressHeader(coinType));
+    }
+
     public static long getPacketMagic() {
         if(Utils.isTestNet()) return testNetPacketMagic;
         else return packetMagic;
     }
 
-    public static final int dumpedPrivateKeyHeader = 151;
-//    public static final int dumpedPrivateKeyHeader = 128;
     public static final int TARGET_TIMESPAN = 14 * 24 * 60 * 60;  // legacy bitcoin: 2 weeks per difficulty cycle, on average.
     public static final int TARGET_SPACING = 1 * 60;  // primecoin block spacing
     public static final int BLOCK_DIFFICULTY_INTERVAL = 2016; // legacy bitcoin

--- a/bitherj/src/main/java/net/bither/bitherj/crypto/DumpedPrivateKey.java
+++ b/bitherj/src/main/java/net/bither/bitherj/crypto/DumpedPrivateKey.java
@@ -20,10 +20,6 @@ import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
 import net.bither.bitherj.PrimerjSettings;
-import net.bither.bitherj.utils.Base58;
-import net.bither.bitherj.utils.Utils;
-
-import net.bither.bitherj.PrimerjSettings;
 import net.bither.bitherj.exception.AddressFormatException;
 import net.bither.bitherj.utils.Base58;
 import net.bither.bitherj.utils.Utils;
@@ -46,7 +42,7 @@ public class DumpedPrivateKey {
 
     // Used by ECKey.getPrivateKeyEncoded()
     public DumpedPrivateKey(byte[] keyBytes, boolean compressed) {
-        version = PrimerjSettings.dumpedPrivateKeyHeader;
+        version = PrimerjSettings.getDumpedPrivateKeyHeader(Utils.getNetType());
         bytes = encode(keyBytes, compressed);
         checkArgument(version < 256 && version >= 0);
         this.compressed = compressed;
@@ -72,16 +68,16 @@ public class DumpedPrivateKey {
      * @param encoded The base58 encoded string.
      * @throws net.bither.bitherj.exception.AddressFormatException If the string is invalid or the header byte doesn't match the network params.
      */
-    public DumpedPrivateKey(String encoded) throws AddressFormatException {
+    public DumpedPrivateKey(String encoded, PrimerjSettings.NetType coinType) throws AddressFormatException {
         //todo string encoded
         byte[] tmp = Base58.decodeChecked(encoded);
         version = tmp[0] & 0xFF;
         bytes = new byte[tmp.length - 1];
         System.arraycopy(tmp, 1, bytes, 0, tmp.length - 1);
 
-        if (version != PrimerjSettings.dumpedPrivateKeyHeader)
+        if (version != PrimerjSettings.getDumpedPrivateKeyHeader(coinType))
             throw new AddressFormatException("Mismatched version number, trying to cross networks? " + version +
-                    " vs " + PrimerjSettings.dumpedPrivateKeyHeader);
+                    " vs " + PrimerjSettings.getDumpedPrivateKeyHeader(coinType));
         if (bytes.length == 33 && bytes[32] == 1) {
             compressed = true;
             bytes = Arrays.copyOf(bytes, 32);  // Chop off the additional marker byte.

--- a/bitherj/src/main/java/net/bither/bitherj/crypto/bip38/Bip38.java
+++ b/bitherj/src/main/java/net/bither/bitherj/crypto/bip38/Bip38.java
@@ -57,7 +57,7 @@ public class Bip38 {
      * @throws InterruptedException
      */
     public static String encryptNoEcMultiply(CharSequence passphrase, String base58EncodedPrivateKey, PrimerjSettings.NetType coinType) throws InterruptedException, AddressFormatException {
-        DumpedPrivateKey dumpedPrivateKey = new DumpedPrivateKey(base58EncodedPrivateKey);
+        DumpedPrivateKey dumpedPrivateKey = new DumpedPrivateKey(base58EncodedPrivateKey, coinType);
         ECKey key = dumpedPrivateKey.getKey();
         dumpedPrivateKey.clearPrivateKey();
         byte[] salt = Bip38.calculateScryptSalt(key.toAddress(coinType));

--- a/bitherj/src/main/java/net/bither/bitherj/factory/ImportPrivateKey.java
+++ b/bitherj/src/main/java/net/bither/bitherj/factory/ImportPrivateKey.java
@@ -24,15 +24,7 @@ import net.bither.bitherj.crypto.PasswordSeed;
 import net.bither.bitherj.crypto.SecureCharSequence;
 import net.bither.bitherj.qrcode.QRCodeUtil;
 import net.bither.bitherj.utils.PrivateKeyUtil;
-
-import net.bither.bitherj.core.Address;
-import net.bither.bitherj.core.AddressManager;
-import net.bither.bitherj.crypto.DumpedPrivateKey;
-import net.bither.bitherj.crypto.ECKey;
-import net.bither.bitherj.crypto.PasswordSeed;
-import net.bither.bitherj.crypto.SecureCharSequence;
-import net.bither.bitherj.qrcode.QRCodeUtil;
-import net.bither.bitherj.utils.PrivateKeyUtil;
+import net.bither.bitherj.utils.Utils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -215,14 +207,14 @@ public abstract class ImportPrivateKey {
         try {
             switch (this.importPrivateKeyType) {
                 case Text:
-                    dumpedPrivateKey = new DumpedPrivateKey(this.content);
+                    dumpedPrivateKey = new DumpedPrivateKey(this.content, Utils.getNetType());
                     ecKey = dumpedPrivateKey.getKey();
                     break;
                 case BitherQrcode:
                     ecKey = PrivateKeyUtil.getECKeyFromSingleString(content, password);
                     break;
                 case Bip38:
-                    dumpedPrivateKey = new DumpedPrivateKey(this.content);
+                    dumpedPrivateKey = new DumpedPrivateKey(this.content, Utils.getNetType());
                     ecKey = dumpedPrivateKey.getKey();
                     break;
             }

--- a/bitherj/src/main/java/net/bither/bitherj/utils/Utils.java
+++ b/bitherj/src/main/java/net/bither/bitherj/utils/Utils.java
@@ -981,7 +981,7 @@ public class Utils {
 
     public static boolean validBitcoinPrivateKey(String str) {
         try {
-            DumpedPrivateKey dumpedPrivateKey = new DumpedPrivateKey(str);
+            DumpedPrivateKey dumpedPrivateKey = new DumpedPrivateKey(str, getNetType());
             dumpedPrivateKey.clearPrivateKey();
             return true;
         } catch (AddressFormatException e) {

--- a/bitherj/src/test/java/net/bither/bitherj/core/AddressTest.java
+++ b/bitherj/src/test/java/net/bither/bitherj/core/AddressTest.java
@@ -19,10 +19,7 @@ package net.bither.bitherj.core;
 import net.bither.bitherj.crypto.DumpedPrivateKey;
 import net.bither.bitherj.crypto.ECKey;
 import net.bither.bitherj.exception.AddressFormatException;
-
-import net.bither.bitherj.crypto.DumpedPrivateKey;
-import net.bither.bitherj.crypto.ECKey;
-import net.bither.bitherj.exception.AddressFormatException;
+import net.bither.bitherj.PrimerjSettings;
 
 import org.junit.Test;
 
@@ -32,10 +29,10 @@ public class AddressTest {
     @Test
     public void testAddress() {
         try {
-            DumpedPrivateKey dumpedPrivateKey = new DumpedPrivateKey("L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1");
+            DumpedPrivateKey dumpedPrivateKey = new DumpedPrivateKey("L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1", PrimerjSettings.NetType.BITCOIN);
             ECKey ecKey = dumpedPrivateKey.getKey();
-            String addressStr = ecKey.toAddress();
-            assertEquals(ecKey.toAddress(), "1F3sAm6ZtwLAUnj7d38pGFxtP3RVEvtsbV");
+            String addressStr = ecKey.toAddress(PrimerjSettings.NetType.BITCOIN);
+            assertEquals(addressStr, "1F3sAm6ZtwLAUnj7d38pGFxtP3RVEvtsbV");
         } catch (AddressFormatException e) {
             e.printStackTrace();
         }

--- a/bitherj/src/test/java/net/bither/bitherj/core/HDMIdTest.java
+++ b/bitherj/src/test/java/net/bither/bitherj/core/HDMIdTest.java
@@ -24,16 +24,7 @@ import net.bither.bitherj.api.UploadHDMBidApi;
 import net.bither.bitherj.core.https.HttpsTest;
 import net.bither.bitherj.crypto.DumpedPrivateKey;
 import net.bither.bitherj.crypto.ECKey;
-import net.bither.bitherj.utils.Utils;
-
-import net.bither.bitherj.api.CreateHDMAddressApi;
-import net.bither.bitherj.api.GetHDMBIdRandomApi;
-import net.bither.bitherj.api.RecoveryHDMApi;
-import net.bither.bitherj.api.SignatureHDMApi;
-import net.bither.bitherj.api.UploadHDMBidApi;
-import net.bither.bitherj.core.https.HttpsTest;
-import net.bither.bitherj.crypto.DumpedPrivateKey;
-import net.bither.bitherj.crypto.ECKey;
+import net.bither.bitherj.PrimerjSettings;
 import net.bither.bitherj.utils.Utils;
 
 import org.junit.Test;
@@ -51,8 +42,8 @@ public class HDMIdTest {
     public void testCreateHDAddress() {
         try {
             HttpsTest.trust();
-            ECKey ecKey = new DumpedPrivateKey("L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1").getKey();
-            String address = ecKey.toAddress();
+            ECKey ecKey = new DumpedPrivateKey("L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1", PrimerjSettings.NetType.BITCOIN).getKey();
+            String address = ecKey.toAddress(PrimerjSettings.NetType.BITCOIN);
             GetHDMBIdRandomApi getHDMBIdRandomApi = new GetHDMBIdRandomApi(address);
             getHDMBIdRandomApi.handleHttpGet();
             long randomKey = getHDMBIdRandomApi.getResult();
@@ -102,8 +93,8 @@ public class HDMIdTest {
     public void testRecoveryHDM() {
         try {
             HttpsTest.trust();
-            ECKey ecKey = new DumpedPrivateKey("L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1").getKey();
-            String address = ecKey.toAddress();
+            ECKey ecKey = new DumpedPrivateKey("L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1", PrimerjSettings.NetType.BITCOIN).getKey();
+            String address = ecKey.toAddress(PrimerjSettings.NetType.BITCOIN);
             System.out.println("eckey:" + address);
             byte[] decryptedPassword = new byte[32];
             for (int i = 0; i < decryptedPassword.length; i++) {


### PR DESCRIPTION
Fix related unit tests
NOTE: earlier TESTNET private key exports are invalid.
NOTE: MAINNET private key exports NOT impacted by this issue.

Broken unit tests down to 20 from 23.