### PR TITLE
Fix bip38 handling to allow unit tests to access Bitcoin private key wif

### DIFF
--- a/bitherj/src/main/java/net/bither/bitherj/crypto/DumpedPrivateKey.java
+++ b/bitherj/src/main/java/net/bither/bitherj/crypto/DumpedPrivateKey.java
@@ -41,8 +41,8 @@ public class DumpedPrivateKey {
     protected byte[] bytes;
 
     // Used by ECKey.getPrivateKeyEncoded()
-    public DumpedPrivateKey(byte[] keyBytes, boolean compressed) {
-        version = PrimerjSettings.getDumpedPrivateKeyHeader(Utils.getNetType());
+    public DumpedPrivateKey(byte[] keyBytes, boolean compressed, PrimerjSettings.NetType coinType) {
+        version = PrimerjSettings.getDumpedPrivateKeyHeader(coinType);
         bytes = encode(keyBytes, compressed);
         checkArgument(version < 256 && version >= 0);
         this.compressed = compressed;

--- a/bitherj/src/main/java/net/bither/bitherj/crypto/bip38/Bip38.java
+++ b/bitherj/src/main/java/net/bither/bitherj/crypto/bip38/Bip38.java
@@ -372,7 +372,7 @@ public class Bip38 {
             // The passphrase is either invalid or we are on the wrong network
             return null;
         }
-        DumpedPrivateKey dumpedPrivateKey = new DumpedPrivateKey(ecKey.getPrivKeyBytes(), ecKey.isCompressed());
+        DumpedPrivateKey dumpedPrivateKey = new DumpedPrivateKey(ecKey.getPrivKeyBytes(), ecKey.isCompressed(), coinType);
         // The result is returned in SIPA format
         SecureCharSequence secureCharSequence = dumpedPrivateKey.toSecureCharSequence();
         dumpedPrivateKey.clearPrivateKey();
@@ -423,7 +423,7 @@ public class Bip38 {
         }
 
         // Get SIPA format
-        DumpedPrivateKey dumpedPrivateKey = new DumpedPrivateKey(key.getPrivKeyBytes(), key.isCompressed());
+        DumpedPrivateKey dumpedPrivateKey = new DumpedPrivateKey(key.getPrivKeyBytes(), key.isCompressed(), coinType);
 
         SecureCharSequence secureCharSequence = dumpedPrivateKey.toSecureCharSequence();
         dumpedPrivateKey.clearPrivateKey();

--- a/bitherj/src/main/java/net/bither/bitherj/utils/PrivateKeyUtil.java
+++ b/bitherj/src/main/java/net/bither/bitherj/utils/PrivateKeyUtil.java
@@ -105,7 +105,7 @@ public class PrivateKeyUtil {
         ECKey ecKey = null;
         SecureCharSequence privateKeyText = null;
         if (needPrivteKeyText) {
-            DumpedPrivateKey dumpedPrivateKey = new DumpedPrivateKey(decrypted, isCompressed);
+            DumpedPrivateKey dumpedPrivateKey = new DumpedPrivateKey(decrypted, isCompressed, Utils.getNetType());
             privateKeyText = dumpedPrivateKey.toSecureCharSequence();
             dumpedPrivateKey.clearPrivateKey();
         } else {


### PR DESCRIPTION
bip38 unit tests now pass
broken unit tests down to 6 from 20